### PR TITLE
[Rust Spec] fix some potential panics and OOMs in the Rust `spec` reference implementation 

### DIFF
--- a/docs/specs/rust/src/circuit/lfc2.rs
+++ b/docs/specs/rust/src/circuit/lfc2.rs
@@ -21,6 +21,18 @@ use crate::{
     io::{read_elt_field, read_uleb128, zigzag_decode_delta},
 };
 
+const MAX_LOGW: usize = 40;
+const MAX_WIRES: usize = 5_000_000;
+const MAX_LAYERS: usize = 10_000;
+const MAX_CONSTANTS: usize = 5_000_000;
+const MAX_DELTAS: usize = 20_000_000;
+const MAX_TERMS_PER_LAYER: usize = 20_000_000;
+const MAX_TOTAL_TERMS: usize = 20_000_000;
+
+fn invalid_data(msg: &'static str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg)
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct Term<F> {
     pub k: F,
@@ -50,29 +62,53 @@ pub struct Circuit<F> {
 pub fn parse_lfc2_bytes<F: Field + 'static, R: Read>(io: &mut R) -> std::io::Result<Circuit<F>> {
     let mut magic = [0u8; 4];
     io.read_exact(&mut magic)?;
-    assert_eq!(&magic, b"LFC2", "Invalid magic header");
+    if &magic != b"LFC2" {
+        return Err(invalid_data("Invalid magic header"));
+    }
 
     let field_id = read_uleb128(io)?;
     let nv = read_uleb128(io)? as usize;
     read_uleb128(io)?;
     let logv = ceil_lg2(nv);
+    if logv > MAX_LOGW {
+        return Err(invalid_data("logv exceeds MAX_LOGW"));
+    }
     let npub_in = read_uleb128(io)? as usize;
     let subfield_boundary = read_uleb128(io)? as usize;
     let ninput = read_uleb128(io)? as usize;
+    if ninput > MAX_WIRES {
+        return Err(invalid_data("ninput exceeds MAX_WIRES"));
+    }
+    if npub_in > ninput {
+        return Err(invalid_data("npublic_input exceeds ninput"));
+    }
     let nl = read_uleb128(io)? as usize;
+    if nl > MAX_LAYERS {
+        return Err(invalid_data("nl exceeds MAX_LAYERS"));
+    }
 
     let num_const = read_uleb128(io)? as usize;
+    if num_const > MAX_CONSTANTS {
+        return Err(invalid_data("num_const exceeds MAX_CONSTANTS"));
+    }
     let mut constants = Vec::with_capacity(num_const);
     for _ in 0..num_const {
         constants.push(read_elt_field(io)?);
     }
 
     let mut layers = Vec::with_capacity(nl);
+    let mut total_terms = 0usize;
     for _ in 0..nl {
         let logw = read_uleb128(io)? as usize;
+        if logw > MAX_LOGW {
+            return Err(invalid_data("logw exceeds MAX_LOGW"));
+        }
         let nw = read_uleb128(io)? as usize;
 
         let num_deltas = read_uleb128(io)? as usize;
+        if num_deltas > MAX_DELTAS {
+            return Err(invalid_data("num_deltas exceeds MAX_DELTAS"));
+        }
         struct Delta {
             g: isize,
             h0: isize,
@@ -90,9 +126,15 @@ pub fn parse_lfc2_bytes<F: Field + 'static, R: Read>(io: &mut R) -> std::io::Res
         }
 
         let num_segments = read_uleb128(io)? as usize;
+        if num_segments > MAX_DELTAS {
+            return Err(invalid_data("num_segments exceeds MAX_DELTAS"));
+        }
         let mut segments = Vec::with_capacity(num_segments);
         for _ in 0..num_segments {
             let seg_len = read_uleb128(io)? as usize;
+            if seg_len > MAX_TERMS_PER_LAYER {
+                return Err(invalid_data("seg_len exceeds MAX_TERMS_PER_LAYER"));
+            }
             let mut seg = Vec::with_capacity(seg_len);
             for _ in 0..seg_len {
                 seg.push(read_uleb128(io)? as usize);
@@ -101,6 +143,9 @@ pub fn parse_lfc2_bytes<F: Field + 'static, R: Read>(io: &mut R) -> std::io::Res
         }
 
         let token_len = read_uleb128(io)? as usize;
+        if token_len > MAX_TERMS_PER_LAYER {
+            return Err(invalid_data("token_len exceeds MAX_TERMS_PER_LAYER"));
+        }
         let mut tokens = Vec::with_capacity(token_len);
         for _ in 0..token_len {
             tokens.push(read_uleb128(io)? as usize);
@@ -109,8 +154,21 @@ pub fn parse_lfc2_bytes<F: Field + 'static, R: Read>(io: &mut R) -> std::io::Res
         let mut hc = Vec::new();
         let (mut g, mut h0, mut h1) = (0isize, 0isize, 0isize);
         for tok in tokens {
+            if tok >= segments.len() {
+                return Err(invalid_data("token index out of bounds"));
+            }
             for &didx in &segments[tok] {
+                if didx >= deltas.len() {
+                    return Err(invalid_data("delta index out of bounds"));
+                }
                 let d = &deltas[didx];
+                if d.k_index >= constants.len() {
+                    return Err(invalid_data("k_index out of bounds"));
+                }
+                if total_terms >= MAX_TOTAL_TERMS {
+                    return Err(invalid_data("total term count exceeds MAX_TOTAL_TERMS"));
+                }
+                total_terms += 1;
                 g += d.g;
                 h0 += d.h0;
                 h1 += d.h1;

--- a/docs/specs/rust/src/io.rs
+++ b/docs/specs/rust/src/io.rs
@@ -23,6 +23,12 @@ pub fn read_uleb128<R: Read>(reader: &mut R) -> std::io::Result<u64> {
         let mut b = [0u8; 1];
         reader.read_exact(&mut b)?;
         let byte = b[0];
+        if shift >= 64 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "uleb128 value exceeds 64 bits",
+            ));
+        }
         val |= ((byte & 0x7f) as u64) << shift;
         if (byte & 0x80) == 0 {
             break;

--- a/docs/specs/rust/src/ligero/proof.rs
+++ b/docs/specs/rust/src/ligero/proof.rs
@@ -103,6 +103,12 @@ pub fn read_ligero_proof<F: Field + 'static, R: Read>(
     }
 
     let num_paths = read_size_4bytes(io)?;
+    if num_paths > 2 * (geom.encoded_len - geom.dblock_len) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "num_paths exceeds Merkle geometry bound",
+        ));
+    }
     let mut merkle_paths = Vec::with_capacity(num_paths);
     for _ in 0..num_paths {
         let mut path = vec![0u8; 32];

--- a/docs/specs/rust/tests/deserializer_hardening_tests.rs
+++ b/docs/specs/rust/tests/deserializer_hardening_tests.rs
@@ -1,0 +1,267 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    fs::File,
+    io::{BufReader, Cursor},
+    path::PathBuf,
+};
+
+use reference::{
+    algebra::{Field, Gf2_128},
+    circuit::{parse_lfc2_bytes, Circuit},
+    ligero::{read_ligero_proof, LigeroConfig, LigeroGeometry},
+};
+
+fn uleb(mut v: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    loop {
+        let mut b = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+        if v == 0 {
+            break;
+        }
+    }
+    out
+}
+
+fn header_nv(nv: u64, nl: u64) -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(b"LFC2");
+    b.extend(uleb(2)); // field_id
+    b.extend(uleb(nv)); // nv
+    b.extend(uleb(0)); // discarded
+    b.extend(uleb(0)); // npub_in
+    b.extend(uleb(0)); // subfield_boundary
+    b.extend(uleb(0)); // ninput
+    b.extend(uleb(nl)); // nl
+    b
+}
+
+fn header(nl: u64) -> Vec<u8> {
+    header_nv(2, nl)
+}
+
+fn parse(bytes: &[u8]) -> std::io::Result<Circuit<Gf2_128>> {
+    let mut cur: &[u8] = bytes;
+    parse_lfc2_bytes::<Gf2_128, _>(&mut cur)
+}
+
+// An unbounded constant count fed to Vec::with_capacity is rejected instead of aborting.
+#[test]
+fn unbounded_constant_count_rejected() {
+    let mut b = header(0);
+    b.extend(uleb(u64::MAX));
+    assert!(parse(&b).is_err());
+}
+
+// A token indexing segments out of range is rejected instead of panicking.
+#[test]
+fn out_of_range_token_index_rejected() {
+    let mut b = header(1);
+    b.extend(uleb(0)); // num_const
+    b.extend(uleb(1)); // logw
+    b.extend(uleb(2)); // nw
+    b.extend(uleb(0)); // num_deltas
+    b.extend(uleb(1)); // num_segments
+    b.extend(uleb(0)); //   seg_len
+    b.extend(uleb(1)); // token_len
+    b.extend(uleb(5)); //   token = 5 -> segments[5]
+    assert!(parse(&b).is_err());
+}
+
+// A segment entry indexing deltas out of range is rejected instead of panicking.
+#[test]
+fn out_of_range_delta_index_rejected() {
+    let mut b = header(1);
+    b.extend(uleb(0)); // num_const
+    b.extend(uleb(1)); // logw
+    b.extend(uleb(2)); // nw
+    b.extend(uleb(1)); // num_deltas = 1
+    b.extend(uleb(0)); // g
+    b.extend(uleb(0)); // h0
+    b.extend(uleb(0)); // h1
+    b.extend(uleb(0)); // k_index
+    b.extend(uleb(1)); // num_segments = 1
+    b.extend(uleb(1)); //   seg_len = 1
+    b.extend(uleb(9)); //     seg[0] = 9 -> deltas[9]
+    b.extend(uleb(1)); // token_len = 1
+    b.extend(uleb(0)); //   token = 0
+    assert!(parse(&b).is_err());
+}
+
+// A delta k_index indexing constants out of range is rejected instead of panicking.
+#[test]
+fn out_of_range_constant_index_rejected() {
+    let mut b = header(1);
+    b.extend(uleb(1)); // num_const = 1
+    b.extend(vec![0u8; Gf2_128::serialized_size()]); // one zero constant
+    b.extend(uleb(1)); // logw
+    b.extend(uleb(2)); // nw
+    b.extend(uleb(1)); // num_deltas = 1
+    b.extend(uleb(0)); // g
+    b.extend(uleb(0)); // h0
+    b.extend(uleb(0)); // h1
+    b.extend(uleb(7)); // k_index = 7
+    b.extend(uleb(1)); // num_segments = 1
+    b.extend(uleb(1)); //   seg_len = 1
+    b.extend(uleb(0)); //     seg[0] = 0
+    b.extend(uleb(1)); // token_len = 1
+    b.extend(uleb(0)); //   token = 0 -> constants[7]
+    assert!(parse(&b).is_err());
+}
+
+// An output count whose ceil_lg2 exceeds MAX_LOGW is rejected at parse instead of panicking
+// downstream on the fixed-size challenge vector.
+#[test]
+fn oversized_output_count_rejected() {
+    let b = header_nv((1u64 << 40) + 1, 0);
+    assert!(parse(&b).is_err());
+}
+
+// Bad magic header is rejected instead of panicking.
+#[test]
+fn magic_header_rejected() {
+    assert!(parse(b"XXXX").is_err());
+}
+
+// Overlong ULEB128 (shift past 64 bits) is rejected instead of panicking/wrapping.
+#[test]
+fn uleb128_overlong_rejected() {
+    let mut b = Vec::new();
+    b.extend_from_slice(b"LFC2");
+    b.extend(std::iter::repeat(0x80u8).take(11)); // field_id: 11 continuation bytes
+    assert!(parse(&b).is_err());
+}
+
+// Per-layer logw > MAX_LOGW is rejected instead of overflowing fixed-size arrays downstream.
+#[test]
+fn layer_logw_rejected() {
+    let mut b = header(1);
+    b.extend(uleb(0)); // num_const
+    b.extend(uleb(41)); // logw = MAX_LOGW + 1
+    assert!(parse(&b).is_err());
+}
+
+// An input count over MAX_WIRES is rejected instead of feeding an unbounded Vec::with_capacity.
+#[test]
+fn oversized_input_count_rejected() {
+    let mut b = Vec::new();
+    b.extend_from_slice(b"LFC2");
+    b.extend(uleb(2)); // field_id
+    b.extend(uleb(2)); // nv
+    b.extend(uleb(0)); // discarded
+    b.extend(uleb(0)); // npub_in
+    b.extend(uleb(0)); // subfield_boundary
+    b.extend(uleb(5_000_001)); // ninput = MAX_WIRES + 1
+    assert!(parse(&b).is_err());
+}
+
+// npublic_input > ninput is rejected instead of underflowing ninput - npublic_input.
+#[test]
+fn npublic_input_gt_ninput_rejected() {
+    let mut b = Vec::new();
+    b.extend_from_slice(b"LFC2");
+    b.extend(uleb(2)); // field_id
+    b.extend(uleb(2)); // nv
+    b.extend(uleb(0)); // discarded
+    b.extend(uleb(5)); // npub_in
+    b.extend(uleb(0)); // subfield_boundary
+    b.extend(uleb(0)); // ninput = 0 < npub_in
+    assert!(parse(&b).is_err());
+}
+
+// Expanded term count is bounded, so a small circuit cannot expand to an OOM.
+// Reaching the cap allocates ~1 GiB; run explicitly with `cargo test -- --ignored`.
+#[test]
+#[ignore]
+fn expanded_terms_rejected() {
+    let mut b = header(1);
+    b.extend(uleb(1)); // num_const = 1
+    b.extend(vec![0u8; Gf2_128::serialized_size()]); // one zero constant
+    b.extend(uleb(1)); // logw
+    b.extend(uleb(2)); // nw
+    b.extend(uleb(1)); // num_deltas = 1
+    b.extend(uleb(0)); // g
+    b.extend(uleb(0)); // h0
+    b.extend(uleb(0)); // h1
+    b.extend(uleb(0)); // k_index
+    b.extend(uleb(1)); // num_segments = 1
+    b.extend(uleb(1)); //   seg_len = 1
+    b.extend(uleb(0)); //     seg[0] = 0
+    let ntok: u64 = 20_000_001; // MAX_TERMS_PER_LAYER + 1 tokens all pointing at segment 0
+    b.extend(uleb(ntok));
+    for _ in 0..ntok {
+        b.extend(uleb(0));
+    }
+    assert!(parse(&b).is_err());
+}
+
+// An attacker-controlled num_paths is rejected against the trusted geometry before allocating.
+#[test]
+fn unbounded_merkle_path_count_rejected() {
+    let config = LigeroConfig::default();
+
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/sha256_circuit.lfc2");
+    let mut circuit_reader = BufReader::new(File::open(path).expect("open circuit"));
+    let circuit =
+        parse_lfc2_bytes::<Gf2_128, _>(&mut circuit_reader).expect("parse circuit");
+
+    let sf = <Gf2_128 as Field>::Subfield::default();
+
+    let witness_only_len = circuit.ninput - circuit.npublic_input;
+    let mut pad_witness_len = 3 * circuit.layers.len();
+    for layer in &circuit.layers {
+        pad_witness_len += 4 * layer.logw;
+    }
+    let nw = witness_only_len + pad_witness_len;
+    let nq = circuit.layers.len();
+    let geom = LigeroGeometry::new(&config, nw, nq);
+
+    let mut stream = Vec::new();
+    for _ in 0..geom.block_len {
+        stream.extend_from_slice(&[0u8; 16]);
+    }
+    for _ in 0..geom.dblock_len {
+        stream.extend_from_slice(&[0u8; 16]);
+    }
+    for _ in 0..geom.num_queries {
+        stream.extend_from_slice(&[0u8; 16]);
+    }
+    for _ in 0..(geom.dblock_len - geom.block_len) {
+        stream.extend_from_slice(&[0u8; 16]);
+    }
+    for _ in 0..geom.num_queries {
+        stream.extend_from_slice(&[0u8; 32]);
+    }
+
+    // One RLE run covering every requested element, so the reader reaches num_paths.
+    let total_req_elts = geom.total_rows * geom.num_queries;
+    stream.extend_from_slice(&(total_req_elts as u32).to_le_bytes());
+    for _ in 0..total_req_elts {
+        stream.extend_from_slice(&[0u8; 16]);
+    }
+
+    // num_paths = u32::MAX must be rejected before Vec::with_capacity.
+    stream.extend_from_slice(&u32::MAX.to_le_bytes());
+
+    let mut cursor = Cursor::new(stream);
+    let result = read_ligero_proof::<Gf2_128, _>(&mut cursor, &config, &circuit, &sf);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
We have been analyzing the libzk spec and its reference implementation in `docs/spec/rust` using our verification tools, and the tools flagged some potential panics and out-of-memory bugs in the code (confirmed with an AI audit and reproduced with tests). Most of the issues occur when parsing/deserializing malformed, untrusted inputs. This is not so serious for a spec, but still might be worth fixing if this code is ever used as a reference implementation.

Note: We confirmed that none of these issues affect the production Rust or C++ implementations. 

The list of issues is below, and suggested fixes are in this PR, along with tests that trigger the panics. We picked fixes that match what is done in the production Rust, but maybe the developers would make a different choice (e.g. document the panics or add asserts etc.) So if you'd like us to convert this into an issue, we can do so. 

-----

## `src/io.rs`

### RustSpec-Panic-1 · `read_uleb128` — unbounded shift (panic / silent wrap)

**Code — `docs/specs/rust/src/io.rs:19-33`:**
```rust
pub fn read_uleb128<R: Read>(reader: &mut R) -> std::io::Result<u64> {
    let mut val = 0u64;
    let mut shift = 0;
    loop {
        let mut b = [0u8; 1];
        reader.read_exact(&mut b)?;
        let byte = b[0];
        val |= ((byte & 0x7f) as u64) << shift;   // :26  shift is never bounded
        if (byte & 0x80) == 0 { break; }
        shift += 7;
    }
    Ok(val)
}
```

**Issue.** Every count and index in a circuit or proof is decoded through this reader. A run of
continuation bytes (`0x80 …`) drives `shift` past 63; `<< shift` then panics (`attempt to shift left
with overflow`) in debug builds or silently produces a wrong value in release. 

**Fix.** Reject once `shift >= 64` before shifting — as production's bounded `read_uleb128_max4`
(`rust/core/proto/src/uleb.rs`) does with a byte-count cap.

**Test that reaches it.** `deserializer_hardening_tests.rs::uleb128_overlong_rejected` 

---

## `src/circuit/lfc2.rs` — `parse_lfc2_bytes`

### RustSpec-Panic-2 · magic-header `assert_eq!` → panic

**Code — `docs/specs/rust/src/circuit/lfc2.rs:51-53`:**
```rust
let mut magic = [0u8; 4];
io.read_exact(&mut magic)?;
assert_eq!(&magic, b"LFC2", "Invalid magic header");   // panics instead of Err
```

**Issue.** Any circuit not beginning with the four bytes `LFC2` panics rather than returning an
error — the most trivially reachable pre-auth panic in the parser (4 wrong bytes).  
This is intentional, but still would be nicer to return an Err.

**Fix.** `return Err(InvalidData)` on mismatch 

**Test.** `deserializer_hardening_tests.rs::magic_header_rejected`

### RustSpec-Panic-3 · `logv` slice past the fixed challenge vector (panic)

**Code — `docs/specs/rust/src/circuit/lfc2.rs:56-58`** (sink at
`zk/symbolic_sumcheck_verifier.rs:180-182`, `MAX_LOGW=40` @ `sumcheck/common.rs:151`):
```rust
let nv = read_uleb128(io)? as usize;   // circuit output count, unchecked
read_uleb128(io)?;
let logv = ceil_lg2(nv);               // > 40 iff nv > 2^40
// ... later: let hc_init = g_ch[0..logv_output].to_vec();  // g_ch.len() == 40 -> panic
```

**Issue.** `noutput` (`nv`) is read unchecked; `ceil_lg2(nv) > 40` iff `nv > 2^40`, and the slice
`g_ch[0..logv_output]` then runs past the fixed 40-element challenge vector → panic, before the
layer loop.

**Fix.** Reject `ceil_lg2(nv) > MAX_LOGW` at parse (production `reader/lfc2.rs:40`; verifier
`sane_logw`).

**Test.** `deserializer_hardening_tests.rs::oversized_output_count_rejected` 

### RustSpec-OOM-4 · `ninput` — unbounded `Vec::with_capacity`

**Code — `docs/specs/rust/src/circuit/lfc2.rs:61`** (sink at
`zk/symbolic_sumcheck_verifier.rs:147`):
```rust
let ninput = read_uleb128(io)? as usize;   // unbounded; later: Vec::with_capacity(num_inputs)
```

**Issue.** `ninput` is an unbounded wire count fed to `Vec::with_capacity` (and an O(ninput) loop) in
the symbolic verifier → metadata-only OOM / `capacity overflow`. 

**Fix.** Cap `ninput <= MAX_WIRES` at parse (like production `reader/lfc2.rs:67`, `MAX_WIRES = 5_000_000`).

**Test.** `deserializer_hardening_tests.rs::oversized_input_count_rejected` — `ninput = MAX_WIRES + 1`; asserts `Err`.

### RustSpec-Panic-5 · `ninput − npublic_input` underflow (panic)

**Code — `docs/specs/rust/src/circuit/lfc2.rs:59,61`** (sink at `ligero/proof.rs:30`,
`zk/verifier.rs:166`):
```rust
let npub_in = read_uleb128(io)? as usize;
let ninput  = read_uleb128(io)? as usize;
// ... later: let witness_only_len = circuit.ninput - circuit.npublic_input;  // underflow
```

**Issue.** `npublic_input` and `ninput` are read independently; nothing enforces
`npublic_input <= ninput`. The subtraction underflows → panic (debug) or, in release, a wrapped
length that indexes out of bounds in the verifier.

**Fix.** Reject `npublic_input > ninput` at parse (production caps both against `MAX_WIRES` and
validates the layout).

**Test.** `deserializer_hardening_tests.rs::npublic_input_gt_ninput_rejected` 

### RustSpec-OOM-6 · ULEB128 counts → unbounded `Vec::with_capacity`

**Code — `docs/specs/rust/src/circuit/lfc2.rs`** (representative; same pattern at each count):
```rust
let num_const = read_uleb128(io)? as usize;         // :64  unbounded u64
let mut constants = Vec::with_capacity(num_const);  // :65  no MAX_* cap
// identical shape: nl:62, num_deltas:75, num_segments:92, seg_len:95, token_len:103
```

**Issue.** Every circuit-wire count is a raw unbounded `read_uleb128` fed straight to
`Vec::with_capacity`. ~10 ULEB128 bytes encode `usize::MAX` → metadata-only OOM or a `capacity
overflow` abort. 

**Fix.** Cap each count against a `MAX_*` before `with_capacity` 

**Test.** `deserializer_hardening_tests.rs::unbounded_constant_count_rejected` — drives the real
`parse_lfc2_bytes` with `num_const = u64::MAX`; asserts `Err` (`capacity overflow` contained by the
cap; no allocation).

### RustSpec-Panic-7 · per-layer `logw` unchecked (OOB fixed-array index)

**Code — `docs/specs/rust/src/circuit/lfc2.rs:72`** (sinks at `sumcheck/proof.rs:37`,
`sumcheck/pad.rs:109`; `4 * logw` at `ligero/proof.rs:33`, `zk/verifier.rs:169`):
```rust
let logw = read_uleb128(io)? as usize;   // per layer, unchecked (RustSpec-Panic-3 caps only the output logv)
```

**Issue.** Each layer's `logw` is unbounded. The proof reader indexes fixed 40-slot challenge arrays
by `logw` → out-of-bounds index panic during proof parsing, and does `Vec::with_capacity(logw)`;
`4 * logw` also overflows. This is the reference-tree analog of upstream **#146** (fixed in the
deployed C++, never ported to this reference).

**Fix.** Reject per-layer `logw > MAX_LOGW` at parse (production `reader/lfc2.rs:117` `sane_logw`).

**Test.** `deserializer_hardening_tests.rs::layer_logw_rejected` 

### RustSpec-Panic-8 · unchecked slice indices (panics)

**Code — `docs/specs/rust/src/circuit/lfc2.rs:111-118`:**
```rust
for tok in tokens {
    for &didx in &segments[tok] {          // :112  tok (wire) unchecked -> index panic
        let d = &deltas[didx];              // :113  didx (wire) unchecked -> index panic
        // ...
        k: constants[d.k_index],            // :118  k_index (wire) unchecked -> index panic
```

**Issue.** `tokens`, the entries of `segments`, and `delta.k_index` are read unchecked from the wire
and used as direct slice indices. Any out-of-range value panics (index out of bounds) → abort.

**Fix.** Bounds-check each index (`tok < segments.len()`, `didx < deltas.len()`,
`k_index < constants.len()`). Note: upstream **#145** is the closely-related C++
off-by-one — `>` vs `>=` — on the same index class.

**Test.** Three tests drive the real `parse_lfc2_bytes` to each index and assert `Err`:
`out_of_range_token_index_rejected` (`segments[5]`, len 1), `out_of_range_delta_index_rejected` (`deltas[9]`, len 1),
`out_of_range_constant_index_rejected` (`constants[7]`, len 1).

### RustSpec-OOM-9 · unbounded expanded-term allocation

**Code — `docs/specs/rust/src/circuit/lfc2.rs:109-123`:**
```rust
let mut hc = Vec::new();
for tok in tokens {
    for &didx in &segments[tok] {   // total pushes = sum over tokens of segments[tok].len()
        hc.push(Term { /* ... */ }); // unbounded; no cap on total expanded terms
    }
}
```

**Issue.** RustSpec-OOM-6 caps `seg_len` and `token_len` individually, but not their **product** nor
the total across layers. A ~9 KB layer (`√(20M)` segment entries × `√(20M)` tokens) expands to ~20M
`Term`s; across `MAX_LAYERS` layers that reaches ~2×10¹¹ terms (~11 TB) — an OOM from a small
circuit. 

**Fix.** Cap the cumulative expanded-term count across all layers at `MAX_TOTAL_TERMS` while pushing

**Test.** `deserializer_hardening_tests.rs::expanded_terms_rejected` (`#[ignore]`; reaching the cap
allocates ~1 GiB — run with `cargo test -- --ignored`) — one segment + `MAX_TOTAL_TERMS+1` tokens;
asserts `Err` instead of OOM.

---

## `src/ligero/proof.rs` — `read_ligero_proof`

### RustSpec-OOM-10 · `num_paths` unbounded allocation (OOM)

**Code — `docs/specs/rust/src/ligero/proof.rs:105-111`** (count from `io.rs:43-48`):
```rust
let num_paths = read_size_4bytes(io)?;                 // raw 4-byte u32, [0, 2^32-1], unvalidated
let mut merkle_paths = Vec::with_capacity(num_paths);  // reserves num_paths * size_of::<Vec<u8>>()
for _ in 0..num_paths {
    let mut path = vec![0u8; 32];
    io.read_exact(&mut path)?;                          // EOFs long before the reservation is used
    merkle_paths.push(path);
}
```

**Issue.** `num_paths` is an attacker-controlled 4-byte wire count reachable from **proof bytes
alone** (`read_zk_proof → read_ligero_proof`). `with_capacity` reserves the full capacity *before*
the read loop, so `FF FF FF FF` requests `4_294_967_295 × 24 = ~96 GiB` in one allocation →
`handle_alloc_error` abort or host memory exhaustion. CWE-770/789.

**Fix.** Cap `num_paths` against the trusted Merkle geometry before reserving 

**Test.** `deserializer_hardening_tests.rs::unbounded_merkle_path_count_rejected` — drives the real
`read_ligero_proof` over a well-formed proof prefix with `num_paths = u32::MAX`; the geometry cap
rejects it (`Err`) **before** allocating, so this is now a runnable real-reach test (the pre-fix code
would OOM — u32·24 B is below `isize::MAX`, so it does not capacity-overflow).

-----




