### PR TITLE
ECDSA circuit proof: loosen pre-condition on ECDSA PK-order to match implementations

### DIFF
--- a/formal/circuits/ECDSA/Ecdsa.lean
+++ b/formal/circuits/ECDSA/Ecdsa.lean
@@ -1402,9 +1402,8 @@ lemma ecdsa_reconstruct_to_infinity (pk : AffinePoint F) (e_nat r_nat s_nat : Na
   have h_e_G_on : e_G.IsOnCurve params := bsmul_on_curve _ G_proj params h_G_on
   have h_r_PK_on : r_PK.IsOnCurve params := bsmul_on_curve _ PK_proj params h_PK_on
   rcases h_std with ⟨h_on_pk, h_pk_order, h_r_pos, h_r_lt, h_s_pos, h_s_lt, h_verify⟩
-  have h_PK_order : ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) PK_proj params) infinityPoint := by
-    have h_std_pk_order := h_pk_order
-    exact h_std_pk_order ▸ ProjectiveEquiv.refl _
+  have h_PK_order : ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) PK_proj params) infinityPoint :=
+    h_pk_order
   have h_G_order_proj : ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) G_proj params) infinityPoint := h_G_order
   have h_order_pos : 0 < order := by omega
   have h_exp1 : (s_nat * ((e_nat % order * s_inv) % order)) % order = (order - (e_nat % order)) % order := by

--- a/formal/circuits/ECDSA/EcdsaSound.lean
+++ b/formal/circuits/ECDSA/EcdsaSound.lean
@@ -60,7 +60,7 @@ theorem ecdsa_circuit_soundness (w : EcdsaWitness F) (pk : AffinePoint F) (e : F
     [h_prime : Fact (Nat.Prime order)]
     (h : ValidEcdsaWitness w pk e order params)
     (h_G_on : ProjectivePoint.IsOnCurve ({ X := params.gx, Y := params.gy : AffinePoint F }).toProjective params)
-    (h_pk_order : bsmul (padBits (natToBits order) params.kBits) pk.toProjective params = infinityPoint)
+    (h_pk_order : ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) pk.toProjective params) infinityPoint)
     (h_G_order : ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) ({ X := params.gx, Y := params.gy : AffinePoint F }).toProjective params) infinityPoint)
     (h_R_order : ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) ({ X := w.rx, Y := w.ry : AffinePoint F }).toProjective params) infinityPoint) :
     ∃ (r s : Nat) (e_nat : Nat),
@@ -173,10 +173,6 @@ theorem ecdsa_circuit_soundness (w : EcdsaWitness F) (pk : AffinePoint F) (e : F
     rw [h_pt_eq]
     exact z_ne_zero_of_point_equality_and_on_curve (addE ({ X := params.gx, Y := params.gy : AffinePoint F }).toProjective ({ X := w.pre.getD 4 0, Y := w.pre.getD 5 0 : AffinePoint F }).toProjective params) (w.pre.getD 6 0) (w.pre.getD 7 0) params h_GRPK_on h_grpk_eq
 
-  have h_PK_order_equiv : ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) pk.toProjective params) infinityPoint := by
-    have h_std_order := h_pk_order
-    exact h_std_order ▸ ProjectiveEquiv.refl _
-
   have ⟨h_s_pos, h_s_lt⟩ := s_range w pk e order params h_copy
   have h_s_inv := exists_mod_inv_of_prime_of_lt_of_pos h_s_lt h_s_pos
   rcases h_s_inv with ⟨s_inv, hs_inv⟩
@@ -184,7 +180,7 @@ theorem ecdsa_circuit_soundness (w : EcdsaWitness F) (pk : AffinePoint F) (e : F
   have h_equiv := ecdsa_algebraic_equivalence bi_nat pk w.rx w.ry w.pre params order
     h_bi_nat_len h_bi_nat_bounds ⟨h_pre_len, h_gpk_eq, h_gr_eq, h_rpk_eq, h_grpk_eq⟩ h_GPK_Z h_GR_Z h_RPK_Z h_GRPK_Z
     h_G_on h_PK_proj_on h_R_proj_on
-    h_G_order h_PK_order_equiv h_R_order
+    h_G_order h_pk_order h_R_order
     ⟨h_pure_x, h_pure_z⟩ s_inv hs_inv
   rcases h_equiv with ⟨h_R_eq, h_RZ_ne⟩
   let z := e_nat % order

--- a/formal/circuits/ECDSA/EcdsaSpec.lean
+++ b/formal/circuits/ECDSA/EcdsaSpec.lean
@@ -28,7 +28,7 @@ def StandardEcdsaVerify (pk : AffinePoint F) (e : Nat) (r s : Nat) (order : Nat)
   -- 1. Public key validation
   pk.IsOnCurve params ∧
   let PK_proj := pk.toProjective
-  bsmul (padBits (natToBits order) params.kBits) PK_proj params = infinityPoint ∧
+  ProjectiveEquiv (bsmul (padBits (natToBits order) params.kBits) PK_proj params) infinityPoint ∧
   
   -- 2. Signature validation
   0 < r ∧ r < order ∧


### PR DESCRIPTION
This is a minor generalization to the ECDSA soundness theorem.

In the top-level ECDSA soundness theorem, two of the hypotheses `h_G_order` and `h_R_order` use `ProjectiveEquiv` to check the order of the corresponding arguments, but the hypothesis `h_pk_order` uses strict equality. This stricter precondition is actually not necessary, as the proof in this PR shows, and `h_pk_order` could also use the weaker `ProjectiveEquiv` formulation.

This becomes relevant when *using* this theorem from a verified implementation of Longfellow, because public-keys do not typically obey the strict equality condition: multiplying them by the group order yields X=Z=0 but Y <> 1.  For example, for the example public key in the spec test suite at `rust/circuits/ecdsa2/tests/all/ecdsa_eval.rs`, we get:

```
pkx = 0x88903e4e1339bde78dd5b3d7baf3efdd72eb5bf5aaaf686c8f9ff5e7c6368d9c
pky = 0xeb8341fc38bb802138498d5f4c03733f457ebbafd0b2fe38e6f58626767f9e75
n·PK = (0, 0xeb09ac52f7751c7733ec7f9cfbe72eee1125cee1b6964a52bfe91b997466e02a, 0)
```

(The same is true for n.G)